### PR TITLE
Improved visual representation of page break element

### DIFF
--- a/src/pagebreakediting.js
+++ b/src/pagebreakediting.js
@@ -58,9 +58,16 @@ export default class PageBreakEditing extends Plugin {
 			view: ( modelElement, viewWriter ) => {
 				const label = t( 'Page break' );
 				const viewWrapper = viewWriter.createContainerElement( 'div' );
+				const viewLabelElement = viewWriter.createContainerElement( 'span' );
+				const innerText = viewWriter.createText( t( 'Page break' ) );
 
 				viewWriter.addClass( 'ck-page-break', viewWrapper );
 				viewWriter.setCustomProperty( 'pageBreak', true, viewWrapper );
+
+				viewWriter.addClass( 'ck-page-break_label', viewLabelElement );
+
+				viewWriter.insert( viewWriter.createPositionAt( viewWrapper, 0 ), viewLabelElement );
+				viewWriter.insert( viewWriter.createPositionAt( viewLabelElement, 0 ), innerText );
 
 				return toPageBreakWidget( viewWrapper, viewWriter, label );
 			}

--- a/tests/pagebreakediting.js
+++ b/tests/pagebreakediting.js
@@ -209,7 +209,7 @@ describe( 'PageBreakEditing', () => {
 				setModelData( model, '<pageBreak></pageBreak>' );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<div class="ck-page-break ck-widget" contenteditable="false"></div>'
+					'<div class="ck-page-break ck-widget" contenteditable="false"><span class="ck-page-break_label">Page break</span></div>'
 				);
 			} );
 

--- a/theme/pagebreak.css
+++ b/theme/pagebreak.css
@@ -4,9 +4,32 @@
  */
 
 .ck .ck-page-break {
+	position: relative;
 	clear: both;
-	padding: 5px;
-	border: 2px dashed var(--ck-color-toolbar-border);
-	border-left: 0;
-	border-right: 0;
+	padding: 5px 0;
+	display: flex;
+	justify-content: center;
+}
+
+.ck .ck-page-break::after {
+	content: '';
+	position: absolute;
+	border-bottom: 2px dashed var(--ck-color-toolbar-border);
+	width: 100%;
+	top: 50%;
+	transform: translateY( -50% );
+}
+
+.ck .ck-page-break_label {
+	position: relative;
+	z-index: var(--ck-z-default);
+	padding: var(--ck-spacing-tiny) var(--ck-spacing-standard);
+	display: block;
+	text-transform: uppercase;
+	border: 1px solid var(--ck-color-toolbar-border);
+	border-radius: var(--ck-border-radius);
+	font-size: var(--ck-font-size-small);
+	font-weight: bold;
+	color: var(--ck-color-toolbar-border);
+	background: var(--ck-color-base-background);
 }

--- a/theme/pagebreak.css
+++ b/theme/pagebreak.css
@@ -8,6 +8,7 @@
 	clear: both;
 	padding: 5px 0;
 	display: flex;
+	align-items: center;
 	justify-content: center;
 }
 
@@ -16,8 +17,6 @@
 	position: absolute;
 	border-bottom: 2px dashed var(--ck-color-toolbar-border);
 	width: 100%;
-	top: 50%;
-	transform: translateY( -50% );
 }
 
 .ck .ck-page-break_label {

--- a/theme/pagebreak.css
+++ b/theme/pagebreak.css
@@ -23,13 +23,14 @@
 .ck .ck-page-break_label {
 	position: relative;
 	z-index: var(--ck-z-default);
-	padding: var(--ck-spacing-tiny) var(--ck-spacing-standard);
+	padding: var(--ck-spacing-small) var(--ck-spacing-standard);
 	display: block;
 	text-transform: uppercase;
 	border: 1px solid var(--ck-color-toolbar-border);
 	border-radius: var(--ck-border-radius);
 	font-size: var(--ck-font-size-small);
 	font-weight: bold;
-	color: var(--ck-color-toolbar-border);
+	color: var(--ck-color-base-text);
 	background: var(--ck-color-base-background);
+	box-shadow: 2px 2px 1px var(--ck-color-shadow-drop);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved visual representation of page break element. Closes ckeditor/ckeditor5#4689.

---

### Additional information
<img width="1450" alt="Screenshot 2019-09-30 at 14 45 50" src="https://user-images.githubusercontent.com/10219857/65879846-04b14400-e391-11e9-9b78-1d742bfc9f87.png">

