### PR TITLE
Disable possibility to select page-break label

### DIFF
--- a/theme/pagebreak.css
+++ b/theme/pagebreak.css
@@ -32,4 +32,10 @@
 	color: var(--ck-color-base-text);
 	background: var(--ck-color-base-background);
 	box-shadow: 2px 2px 1px var(--ck-color-shadow-drop);
+
+	/* Disable posssibility to select label text by user. */
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }

--- a/theme/pagebreak.css
+++ b/theme/pagebreak.css
@@ -34,8 +34,8 @@
 	box-shadow: 2px 2px 1px var(--ck-color-shadow-drop);
 
 	/* Disable posssibility to select label text by user. */
-	-moz-user-select: none;
 	-webkit-user-select: none;
+	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Disable possibility to select page-break label. Closes ckeditor/ckeditor5#4688.

---

### Additional information

We need to use prefixes for `user-select`: https://caniuse.com/#search=user-select.
