### PR TITLE
Page break label element should have a fixed font

### DIFF
--- a/theme/pagebreak.css
+++ b/theme/pagebreak.css
@@ -27,6 +27,7 @@
 	text-transform: uppercase;
 	border: 1px solid var(--ck-color-toolbar-border);
 	border-radius: var(--ck-border-radius);
+	font-family: var(--ck-font-face);
 	font-size: var(--ck-font-size-small);
 	font-weight: bold;
 	color: var(--ck-color-base-text);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Page break label element should have a fixed font. Closes ckeditor/ckeditor5#4687 .

---

### Additional information

![Screen Shot 2019-10-01 at 15 03 24](https://user-images.githubusercontent.com/10219857/65964188-ac477880-e45c-11e9-877a-a863c04e68d0.png)
