### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/pagebreakui.js
+++ b/src/pagebreakui.js
@@ -35,7 +35,10 @@ export default class PageBreakUI extends Plugin {
 			view.bind( 'isEnabled' ).to( command, 'isEnabled' );
 
 			// Execute command.
-			this.listenTo( view, 'execute', () => editor.execute( 'pageBreak' ) );
+			this.listenTo( view, 'execute', () => {
+				editor.execute( 'pageBreak' );
+				editor.editing.view.focus();
+			} );
 
 			return view;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. 

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066
